### PR TITLE
Add the ability to disable Recipe Calculation

### DIFF
--- a/src/main/java/com/buuz135/replication/ReplicationConfig.java
+++ b/src/main/java/com/buuz135/replication/ReplicationConfig.java
@@ -57,7 +57,8 @@ public class ReplicationConfig {
     @ConfigFile.Child(ReplicationConfig.class)
     public class RecipeCalculation {
 
-        @ConfigVal.InRangeInt(min = 1)
+        @ConfigVal(comment = "Setting this to 0 will disable the recipe calculation")
+        @ConfigVal.InRangeInt(min = 0)
         public static int MAX_RECIPE_DEPTH = 11;
 
         @ConfigVal

--- a/src/main/java/com/buuz135/replication/calculation/ReplicationCalculation.java
+++ b/src/main/java/com/buuz135/replication/calculation/ReplicationCalculation.java
@@ -215,6 +215,7 @@ public class ReplicationCalculation {
             }
         } else {
             //CALCULATE
+            if(ReplicationConfig.RecipeCalculation.MAX_RECIPE_DEPTH == 0) return null;
             var name = getNameFromStack(item);
             if (SORTED_CALCULATION_REFERENCE.containsKey(name)) {
                 if (printDebug)


### PR DESCRIPTION
If the config value for `MAX_RECIPE_DEPTH` is set to 0 recipe calculation will be skipped

dunno how clean the `return null` is, technically shouldnt matter since there is a null check further up anyways, but feel free to ignore this

Merging this would resolve #30