### PR TITLE
Fixed crash when clicking number button in replication request widget when text box is empty

### DIFF
--- a/src/main/java/com/buuz135/replication/client/gui/ReplicationRequestWidget.java
+++ b/src/main/java/com/buuz135/replication/client/gui/ReplicationRequestWidget.java
@@ -17,6 +17,7 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 
+import java.lang.NumberFormatException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,7 +70,12 @@ public class ReplicationRequestWidget extends AbstractWidget implements Renderab
     }
 
     public void addNumber(int number){
-        var current = Long.parseLong(this.amountBox.getValue());
+        long current = 0;
+        try  {
+            current = Long.parseLong(this.amountBox.getValue());
+        } catch (NumberFormatException e) {
+            // Should only happen when the text box is empty. Can't parse an empty string as a number, so we'll just use the default 0
+        }
         if (current == 1 && number != 1){
             current = number;
         } else {


### PR DESCRIPTION
I was playing FTB OceanBlock2 and found a bug that crashes the game. I tested, it's still a thing by itself, not a modpack issue. When you're choosing the amount of an item to request, you can type in a number, and you can also press buttons to increment/decrement the number by a certain amount. However, if I delete the number in the text box, then click one of the increment/decrement buttons, the game crashes because it tries to parse that empty string a long number. This PR just fixes that. If Long.parseLong throws a NumberFormatException, which should only happen when the string is empty (though if there's other situations that I didn't find, then I guess I fixed more crashes?), it just acts like the number was 0, which later code handles just fine.