### PR TITLE
Fix "Element network is null" crash in NetworkBlockEntity

### DIFF
--- a/src/main/java/com/buuz135/replication/block/tile/BaseMatterTankBlockEntity.java
+++ b/src/main/java/com/buuz135/replication/block/tile/BaseMatterTankBlockEntity.java
@@ -10,6 +10,7 @@ import com.buuz135.replication.api.network.IMatterTanksSupplier;
 import com.buuz135.replication.client.gui.ReplicationAddonProvider;
 import com.buuz135.replication.client.gui.addons.MatterTankPriorityAddon;
 import com.buuz135.replication.container.component.LockableMatterTankBundle;
+import com.buuz135.replication.network.MatterNetwork;
 import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.api.client.AssetTypes;
 import com.hrznstudio.titanium.block.BasicTileBlock;
@@ -62,10 +63,13 @@ public abstract class BaseMatterTankBlockEntity<T extends BaseMatterTankBlockEnt
 
     private void onTankContentChange() {
         syncObject(this.lockableMatterTankBundle);
-        this.getNetwork().onTankValueChanged(cachedType);
+        MatterNetwork network = this.getNetwork();
+        if (network == null) return;  // Early return если сеть не готова
+
+        network.onTankValueChanged(cachedType);
         if (!cachedType.equals(this.lockableMatterTankBundle.getTank().getMatter().getMatterType())) {
             this.cachedType = this.lockableMatterTankBundle.getTank().getMatter().getMatterType();
-            this.getNetwork().onTankValueChanged(cachedType);
+            network.onTankValueChanged(cachedType);
         }
     }
 

--- a/src/main/java/com/buuz135/replication/block/tile/ChipStorageBlockEntity.java
+++ b/src/main/java/com/buuz135/replication/block/tile/ChipStorageBlockEntity.java
@@ -108,7 +108,10 @@ public class ChipStorageBlockEntity extends NetworkBlockEntity<ChipStorageBlockE
             }
             syncObject(this.chips);
             cachePatterns();
-            this.getNetwork().onChipValuesChanged(this, this.worldPosition);
+            var network = this.getNetwork();
+            if (network != null) {
+                network.onChipValuesChanged(this, this.worldPosition);
+            }
         }
     }
 

--- a/src/main/java/com/buuz135/replication/block/tile/MatterPipeBlockEntity.java
+++ b/src/main/java/com/buuz135/replication/block/tile/MatterPipeBlockEntity.java
@@ -1,6 +1,7 @@
 package com.buuz135.replication.block.tile;
 
 import com.buuz135.replication.ReplicationConfig;
+import com.buuz135.replication.network.MatterNetwork;
 import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.block.BasicTileBlock;
 import com.hrznstudio.titanium.block_network.element.NetworkElement;
@@ -34,13 +35,14 @@ public class MatterPipeBlockEntity extends NetworkBlockEntity<MatterPipeBlockEnt
                 this.needsToRecreateEnergyStorage = false;
                 this.level.updateNeighborsAt(this.worldPosition, this.getBlockState().getBlock());
             }
+            MatterNetwork network = this.getNetwork();
             for (Direction value : Direction.values()) {
                 var capability = this.level.getCapability(Capabilities.EnergyStorage.BLOCK, this.worldPosition.relative(value), value.getOpposite());
                 var tile = this.level.getBlockEntity(this.worldPosition.relative(value));
-                if (capability != null && !(tile instanceof MatterPipeBlockEntity) && this.getNetwork() != null){
-                    var simulatedExtract = this.getNetwork().getEnergyStorage().extractEnergy(ReplicationConfig.MatterPipe.POWER_TRANSFER, true);
+                if (capability != null && !(tile instanceof MatterPipeBlockEntity) && network != null){
+                    var simulatedExtract = network.getEnergyStorage().extractEnergy(ReplicationConfig.MatterPipe.POWER_TRANSFER, true);
                     var realExtracted = capability.receiveEnergy(simulatedExtract, false);
-                    this.getNetwork().getEnergyStorage().extractEnergy(realExtracted, false);
+                    network.getEnergyStorage().extractEnergy(realExtracted, false);
                 }
             }
         }

--- a/src/main/java/com/buuz135/replication/block/tile/NetworkBlockEntity.java
+++ b/src/main/java/com/buuz135/replication/block/tile/NetworkBlockEntity.java
@@ -21,6 +21,7 @@ import java.util.List;
 public abstract class NetworkBlockEntity<T extends ActiveTile<T>> extends ActiveTile<T> implements ITickableBlockEntity<T> {
 
     private List<MatterTankComponent<T>> matterTankComponents;
+    private boolean needsNetworkRegistration = false;
 
     public NetworkBlockEntity(BasicTileBlock<T> base, BlockEntityType<?> blockEntityType, BlockPos pos, BlockState state) {
         super(base, blockEntityType, pos, state);
@@ -41,7 +42,39 @@ public abstract class NetworkBlockEntity<T extends ActiveTile<T>> extends Active
             NetworkManager networkManager = NetworkManager.get(level);
 
             if (networkManager.getElement(worldPosition) == null) {
-                networkManager.addElement(createElement(level, worldPosition));
+                try {
+                    networkManager.addElement(createElement(level, worldPosition));
+                } catch (RuntimeException e) {
+                    // Titanium может выбросить "Element network is null!" при попытке объединить сети
+                    // Это происходит, когда соседние элементы еще не инициализированы
+                    // Отложим регистрацию на следующий тик
+                    if (e.getMessage() != null && e.getMessage().contains("Element network is null")) {
+                        needsNetworkRegistration = true;
+                    } else {
+                        throw e; // Пробросить исключение, если это другая проблема
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void serverTick(Level level, BlockPos pos, BlockState state, T blockEntity) {
+        // Попытка повторной регистрации, если не удалось при onLoad
+        if (needsNetworkRegistration) {
+            NetworkManager networkManager = NetworkManager.get(level);
+            if (networkManager.getElement(worldPosition) == null) {
+                try {
+                    networkManager.addElement(createElement(level, worldPosition));
+                    needsNetworkRegistration = false;
+                } catch (RuntimeException e) {
+                    // Если все еще не удается, попробуем в следующий тик
+                    if (e.getMessage() == null || !e.getMessage().contains("Element network is null")) {
+                        throw e;
+                    }
+                }
+            } else {
+                needsNetworkRegistration = false;
             }
         }
     }
@@ -75,12 +108,14 @@ public abstract class NetworkBlockEntity<T extends ActiveTile<T>> extends Active
             NetworkElement pipe = networkManager.getElement(worldPosition);
             if (pipe != null) {
                 //spawnDrops(pipe);
+
+                // Переместить внутрь блока null-проверки
+                if (pipe.getNetwork() instanceof MatterNetwork matterNetwork){
+                    matterNetwork.removeElement(pipe);
+                }
             }
 
             networkManager.removeElement(worldPosition);
-            if (pipe.getNetwork() instanceof MatterNetwork matterNetwork){
-                matterNetwork.removeElement(pipe);
-            }
         }
     }
 
@@ -89,7 +124,10 @@ public abstract class NetworkBlockEntity<T extends ActiveTile<T>> extends Active
     }
 
     public MatterNetwork getNetwork(){
-        return (MatterNetwork) NetworkManager.get(this.level).getElement(worldPosition).getNetwork();
+        if (this.level == null) return null;
+        NetworkElement element = NetworkManager.get(this.level).getElement(worldPosition);
+        if (element == null) return null;
+        return (MatterNetwork) element.getNetwork();
     }
 
     public List<MatterTankComponent<T>> getMatterTankComponents() {

--- a/src/main/java/com/buuz135/replication/block/tile/ReplicationTerminalBlockEntity.java
+++ b/src/main/java/com/buuz135/replication/block/tile/ReplicationTerminalBlockEntity.java
@@ -3,6 +3,7 @@ package com.buuz135.replication.block.tile;
 import com.buuz135.replication.ReplicationRegistry;
 import com.buuz135.replication.api.pattern.IMatterPatternHolder;
 import com.buuz135.replication.container.ReplicationTerminalContainer;
+import com.buuz135.replication.network.MatterNetwork;
 import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.block.BasicTileBlock;
 import com.hrznstudio.titanium.block_network.element.NetworkElement;
@@ -78,21 +79,27 @@ public class ReplicationTerminalBlockEntity extends NetworkBlockEntity<Replicati
             return ItemInteractionResult.SUCCESS;
         }
         if (playerIn instanceof ServerPlayer serverPlayer) {
-            for (NetworkElement chipSupplier : this.getNetwork().getChipSuppliers()) {
+            MatterNetwork network = this.getNetwork();
+            if (network == null) {
+                // Сеть не готова - не открываем GUI
+                return ItemInteractionResult.FAIL;
+            }
+
+            for (NetworkElement chipSupplier : network.getChipSuppliers()) {
                 var tile = chipSupplier.getLevel().getBlockEntity(chipSupplier.getPos());
                 if (tile instanceof IMatterPatternHolder holder){
-                    this.getNetwork().sendPatternSyncPacket(serverPlayer, holder, tile.getBlockPos());
+                    network.sendPatternSyncPacket(serverPlayer, holder, tile.getBlockPos());
                 }
             }
-            ReplicationRegistry.MATTER_TYPES_REGISTRY.forEach(iMatterType -> this.getNetwork().sendMatterSyncPacket(serverPlayer, this.getNetwork().calculateMatterAmount(iMatterType), iMatterType));
+            ReplicationRegistry.MATTER_TYPES_REGISTRY.forEach(iMatterType -> network.sendMatterSyncPacket(serverPlayer, network.calculateMatterAmount(iMatterType), iMatterType));
             this.getLevel().getServer().submitAsync(() -> {
-                this.getNetwork().getTaskManager().getPendingTasks().values().forEach(task -> {
-                    this.getNetwork().sendTaskSyncPacket(serverPlayer, task);
+                network.getTaskManager().getPendingTasks().values().forEach(task -> {
+                    network.sendTaskSyncPacket(serverPlayer, task);
                 });
             });
             serverPlayer.openMenu(this, buffer -> {
                 LocatorFactory.writePacketBuffer(buffer, new TileEntityLocatorInstance(this.worldPosition));
-                buffer.writeUtf(this.getNetwork().getId());
+                buffer.writeUtf(network.getId());
                 buffer.writeInt(this.sortingTypeValue);
                 buffer.writeInt(this.sortingDirection);
                 buffer.writeInt(this.matterOpediaSortingTypeValue);

--- a/src/main/java/com/buuz135/replication/block/tile/ReplicatorBlockEntity.java
+++ b/src/main/java/com/buuz135/replication/block/tile/ReplicatorBlockEntity.java
@@ -8,6 +8,7 @@ import com.buuz135.replication.block.ReplicatorBlock;
 import com.buuz135.replication.calculation.ReplicationCalculation;
 import com.buuz135.replication.client.gui.addons.ReplicatorCraftingAddon;
 import com.buuz135.replication.client.gui.addons.ReplicatorMotorAddon;
+import com.buuz135.replication.network.MatterNetwork;
 import com.hrznstudio.titanium.annotation.Save;
 import com.hrznstudio.titanium.api.IFactory;
 import com.hrznstudio.titanium.api.client.AssetTypes;
@@ -165,7 +166,8 @@ public class ReplicatorBlockEntity extends ReplicationMachine<ReplicatorBlockEnt
             syncObject(this.progressBarComponent);
             syncObject(this.progress);
         }
-        if (getNetwork() == null) return;
+        MatterNetwork network = getNetwork();
+        if (network == null) return;
         if (ReplicationCalculation.STATUS != MatterCalculationStatus.CALCULATED) return;
         if (this.redstoneManager.getAction().canRun(this.getEnvironmentValue(false, null)) && this.redstoneManager.shouldWork()){
             tickProgress();
@@ -180,11 +182,11 @@ public class ReplicatorBlockEntity extends ReplicationMachine<ReplicatorBlockEnt
                 this.craftingStack = task.getReplicatingStack();
                 syncObject(this.craftingStack);
                 syncObject(this.isCurrentTaskAFailure);
-                this.getNetwork().getTaskManager().getPendingTasks().put(task.getUuid().toString(), task);
-                this.getNetwork().onTaskValueChanged(task, (ServerLevel) this.level);
+                network.getTaskManager().getPendingTasks().put(task.getUuid().toString(), task);
+                network.onTaskValueChanged(task, (ServerLevel) this.level);
             }
             if (this.level.getGameTime() % 4 == 0 && this.craftingTask == null) {
-                var task = this.getNetwork().getTaskManager().findTaskForReplicator(this.getBlockPos(), this.getNetwork());
+                var task = network.getTaskManager().findTaskForReplicator(this.getBlockPos(), network);
                 if (task != null){
                     task.acceptReplicator(this.getBlockPos());
                     this.isCurrentTaskAFailure = this.level.getRandom().nextInt(100) < getFailureChance();
@@ -193,12 +195,12 @@ public class ReplicatorBlockEntity extends ReplicationMachine<ReplicatorBlockEnt
                     this.craftingStack = task.getReplicatingStack();
                     syncObject(this.craftingStack);
                     syncObject(this.isCurrentTaskAFailure);
-                    this.getNetwork().onTaskValueChanged(task, (ServerLevel) this.level);
+                    network.onTaskValueChanged(task, (ServerLevel) this.level);
                 }
             }
             if (this.level.getGameTime() % 4 == 0 && this.craftingTask != null && this.cachedReplicationTask == null) {
-                if (this.getNetwork().getTaskManager().getPendingTasks().containsKey(this.craftingTask)) {
-                    this.cachedReplicationTask = this.getNetwork().getTaskManager().getPendingTasks().get(this.craftingTask);
+                if (network.getTaskManager().getPendingTasks().containsKey(this.craftingTask)) {
+                    this.cachedReplicationTask = network.getTaskManager().getPendingTasks().get(this.craftingTask);
                     this.craftingStack = this.cachedReplicationTask.getReplicatingStack();
                     syncObject(this.craftingStack);
                 } else {
@@ -207,7 +209,7 @@ public class ReplicatorBlockEntity extends ReplicationMachine<ReplicatorBlockEnt
             }
             if (this.level.getGameTime() % 4 == 0 && this.craftingTask != null && this.cachedReplicationTask != null
                     && !this.cachedReplicationTask.getStoredMatterStack().containsKey(this.getBlockPos().asLong())){
-                this.cachedReplicationTask.storeMatterStacksFor(this.level, this.getBlockPos(), this.getNetwork());
+                this.cachedReplicationTask.storeMatterStacksFor(this.level, this.getBlockPos(), network);
             }
         }
     }
@@ -271,8 +273,11 @@ public class ReplicatorBlockEntity extends ReplicationMachine<ReplicatorBlockEnt
     }
 
     private void replicateItem(){
-        this.cachedReplicationTask.finalizeReplication(this.level, this.getBlockPos(), this.getNetwork());
-        this.getNetwork().onTaskValueChanged(this.cachedReplicationTask, (ServerLevel) this.level);
+        MatterNetwork network = this.getNetwork();
+        if (network == null) return;
+
+        this.cachedReplicationTask.finalizeReplication(this.level, this.getBlockPos(), network);
+        network.onTaskValueChanged(this.cachedReplicationTask, (ServerLevel) this.level);
         if (!this.getBlockPos().equals(this.cachedReplicationTask.getSource())){
             var capability = this.level.getCapability(Capabilities.ItemHandler.BLOCK, this.cachedReplicationTask.getSource(), Direction.UP);
                 if (capability != null){
@@ -297,7 +302,10 @@ public class ReplicatorBlockEntity extends ReplicationMachine<ReplicatorBlockEnt
         if (this.cachedReplicationTask != null) {
             this.cachedReplicationTask.getReplicatorsOnTask().remove(this.getBlockPos().asLong());
             if (this.cachedReplicationTask.getReplicatorsOnTask().isEmpty()) {
-                this.getNetwork().cancelTask(this.craftingTask, this.level);
+                MatterNetwork network = this.getNetwork();
+                if (network != null) {
+                    network.cancelTask(this.craftingTask, this.level);
+                }
             }
         }
         super.setRemoved();

--- a/src/main/java/com/buuz135/replication/container/ReplicationTerminalContainer.java
+++ b/src/main/java/com/buuz135/replication/container/ReplicationTerminalContainer.java
@@ -1,6 +1,7 @@
 package com.buuz135.replication.container;
 
 import com.buuz135.replication.block.tile.ReplicationTerminalBlockEntity;
+import com.buuz135.replication.network.MatterNetwork;
 import com.hrznstudio.titanium.api.IFactory;
 import com.hrznstudio.titanium.container.addon.UpdatableSlotItemHandler;
 import com.hrznstudio.titanium.network.locator.LocatorFactory;
@@ -76,7 +77,10 @@ public class ReplicationTerminalContainer extends AbstractContainerMenu {
         if (inventory.player instanceof ServerPlayer serverPlayer)
             this.blockEntity.getTerminalPlayerTracker().addPlayer(serverPlayer);
         this.position = this.blockEntity.getBlockPos();
-        this.network = blockEntity.getNetwork().getId();
+
+        MatterNetwork network = blockEntity.getNetwork();
+        this.network = network != null ? network.getId() : "";
+
         this.addExtraSlots();
         this.initInventory();
     }


### PR DESCRIPTION
Fixed multiple NullPointerException crashes related to network initialization:

- NetworkBlockEntity.getNetwork(): Added null checks for level and element
- NetworkBlockEntity.onLoad(): Added try-catch with deferred registration for Titanium's network merge exception
- NetworkBlockEntity.serverTick(): Added retry logic for failed network registrations
- NetworkBlockEntity.setRemoved(): Moved network removal inside null check block

- BaseMatterTankBlockEntity.onTankContentChange(): Added null check with early return
- ChipStorageBlockEntity.notifyNetworkOfSlotChange(): Added null check (already fixed)
- ReplicationTerminalBlockEntity.onActivated(): Added null check and cached network reference
- ReplicatorBlockEntity.serverTick(): Cached network reference to prevent multiple calls
- ReplicatorBlockEntity.replicateItem(): Added null check
- ReplicatorBlockEntity.setRemoved(): Added null check
- MatterPipeBlockEntity.serverTick(): Cached network reference
- ReplicationTerminalContainer constructor: Added null check with fallback to empty string

The crash occurred when Titanium's NetworkManager tried to merge networks before all elements were fully initialized. Now the code safely handles null networks and retries registration on the next tick if needed.