### PR TITLE
Fixed "Locking does not work"

### DIFF
--- a/src/main/java/com/buuz135/replication/api/matter_fluid/MatterStack.java
+++ b/src/main/java/com/buuz135/replication/api/matter_fluid/MatterStack.java
@@ -79,7 +79,7 @@ public class MatterStack {
     }*/
 
     public final IMatterType getMatterType() {
-        return isEmpty ? MatterType.EMPTY : matter;
+        return matter;
     }
 
     public boolean isEmpty() {


### PR DESCRIPTION
Filter doesn't work at all because LockableMatterTankBundle ignores the previous state of filter in NBT LockableMatterTankBundle creates a new NBT based on isEmpty.

1. LockableMatterTankBundle._**serializeNBT**_() -> 
2. compoundNBT.put("Filter", this.filter._**writeToNBT**_(new CompoundTag())); -> 
3. nbt.putString("MatterName", ReplicationRegistry.MATTER_TYPES_REGISTRY.get().getKey(_**getMatterType**_()).toString()); -> 
4. isEmpty ? _**MatterType.EMPTY**_ : matter; 

(matter = Earth, isEmpty = true => returns MatterType.EMPTY)